### PR TITLE
✨ (hackathon) Add reusable workflow to update Linear with releases

### DIFF
--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           prev_tag=${{ steps.previous_release.outputs.tag_name }}
           current_tag=${{ github.ref_name }}
-          pr_numbers_json=$(git log $prev_tag..$current_tag --merges --first-parent --pretty=%s | grep -oE 'Merge pull request #[0-9]+' | grep -oE '[0-9]+' | jq -sR 'split("\n") | map(select(length > 0)) | map(tonumber)')
+          pr_numbers_json=$(git log $prev_tag..$current_tag --pretty=%s | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | jq -sR 'split("\n") | map(select(length > 0)) | map(tonumber)')
           echo "numbers=${pr_numbers_json}" >> $GITHUB_OUTPUT
 
       - name: Find and update Linear tickets
@@ -119,34 +119,43 @@ jobs:
                 return;
               }
               core.info(`Found ${teamName} tickets: ${Array.from(ticketIDs).join(', ')}`);
-              for (const ticketId of ticketIDs) {
-                try {
-                  core.info(`Updating ${teamName} ticket ${ticketId} to state ${stateId}`);
-                  const updateQuery = `
-                    mutation UpdateIssueStatus($issueId: String!, $stateId: String!) {
-                      issueUpdate(id: $issueId, input: { stateId: $stateId }) {
-                        success
-                        issue {
+
+              const updatePromises = Array.from(ticketIDs).map(ticketId => {
+                core.info(`Updating ${teamName} ticket ${ticketId} to state ${stateId}`);
+                const updateQuery = `
+                  mutation UpdateIssueStatus($issueId: String!, $stateId: String!) {
+                    issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+                      success
+                      issue {
+                        id
+                        state {
                           id
-                          state {
-                            id
-                            name
-                          }
+                          name
                         }
                       }
-                    }`;
-                  const updateResult = await linearQuery(updateQuery, { issueId: ticketId, stateId: stateId });
-            
+                    }
+                  }`;
+                return linearQuery(updateQuery, { issueId: ticketId, stateId: stateId });
+              });
+
+              const updateResults = await Promise.allSettled(updatePromises);
+
+              updateResults.forEach((result, index) => {
+                const ticketId = Array.from(ticketIDs)[index];
+                if (result.status === 'fulfilled') {
+                  const updateResult = result.value;
                   if (updateResult.issueUpdate.success) {
                     core.info(`Successfully updated ticket ${ticketId} to state "${updateResult.issueUpdate.issue.state.name}".`);
                   } else {
                     core.error(`Failed to update ticket ${ticketId}, success was false.`);
                   }
-                } catch (error) {
-                  core.error(`Error processing ticket ${ticketId}: ${error.message}`);
+                } else {
+                  core.error(`Error processing ticket ${ticketId}: ${result.reason.message}`);
                 }
-              }
+              });
             }
             
-            await updateTickets(platformTicketIDs, TEAM_RELEASED_STATE_MAP.platform, 'Team Platform');
-            await updateTickets(coreTicketIDs, TEAM_RELEASED_STATE_MAP.core, 'Team Core'); 
+            await Promise.all([
+              updateTickets(platformTicketIDs, TEAM_RELEASED_STATE_MAP.platform, 'Team Platform'),
+              updateTickets(coreTicketIDs, TEAM_RELEASED_STATE_MAP.core, 'Team Core')
+            ]); 


### PR DESCRIPTION
Related PRs:
- https://github.com/kindly-ai/kindly/pull/8322

## 📝 Summary
- The goal of this PR is to introduce a reusable workflow that is meant to be called by other repos. 
- The goal of the workflow is to find all Linear tickets associated with all PRs that get released and update their status in Linear to "Released". 
- This will be very helpful because, as a consequence, any Slack thread synced with the Linear task will get an update about the _task being released_.

## ☑ Checklist
- [x] I have linked this PR to a Linear Card: fixes PLAT-1181.
- [ ] (_optional_) I plan to write about this PR in #product-updates / Canny / Help Center / Docs / [API Changelog](https://docs.kindly.ai/api/changelog)
- [ ] (_optional_) I have added prometheus or mixpanel events for this feature.
- [ ] (_optional_) I have added tests. 

<!-- 
📝 Summary - Briefly describe what has changed in this pull request. - If this is still a work in progress, create a draft PR. 
✨ Screenshots/GIFs - Include screenshots, videos and/or GIFs showcasing the changes, if applicable. It really helps to understand the changes.
💁‍♂️ Reviewer Instructions - Provide any special instructions for reviewers: - Highlight areas of the code that need more attention. - Note dependencies, context, or questions that will help the reviewer. 
🚀 Deployment Steps - If there are environment variables, migrations, or dependent PRs, mention them here. - Provide step-by-step deployment instructions if necessary. 
☑ Checklist - Make sure to check off all applicable items before submitting. - Link this PR to its relevant Linear Card. - Consider adding observability (e.g., Prometheus/Mixpanel) for new features. - Add/update tests as needed to ensure reliability. 
💡 Additional Notes: - Check out gitmoji-cli for easy lookups: https://github.com/carloscuesta/gitmoji-cli. - Provide a meaningful PR title starting with a gitmoji (see https://gitmoji.dev/ for examples). - Consider mentioning changes in #product-updates, Canny, the Help Center, or API changelogs, as needed. 
-->
