### PR TITLE
✨ Enhance linear-release workflow to include commenting on Slack thread when task is released

### DIFF
--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -145,7 +145,7 @@ jobs:
 
               core.info(`Found ${teamName} tickets to update: ${ticketsToUpdate.join(', ')}`);
 
-              const updatePromises = ticketsToUpdate.map(ticketIdentifier => {
+              const updatePromises = ticketsToUpdate.map(async ticketIdentifier => {
                 core.info(`Updating ${teamName} ticket ${ticketIdentifier} to state ${stateId}`);
                 const updateQuery = `
                   mutation UpdateIssueStatus($issueId: String!, $stateId: String!) {
@@ -160,7 +160,29 @@ jobs:
                       }
                     }
                   }`;
-                return linearQuery(updateQuery, { issueId: ticketIdentifier, stateId: stateId });
+                
+                const result = await linearQuery(updateQuery, { issueId: ticketIdentifier, stateId: stateId });
+
+                if (result.issueUpdate?.success) {
+                  const commentQuery = `
+                    mutation CreateComment($issueId: String!, $body: String!) {
+                      commentCreate(input: { issueId: $issueId, body: $body, createOnSyncedSlackThread: true }) {
+                        success
+                      }
+                    }`;
+                  try {
+                    await linearQuery(commentQuery, { 
+                      issueId: ticketIdentifier, 
+                      body: "This task has been now released to the public 🚀" 
+                    });
+                    core.info(`Successfully commented on synced Slack thread for ticket ${ticketIdentifier}.`);
+                  } catch (e) {
+                    // Linear API throws if no synced thread exists when createOnSyncedSlackThread is true
+                    core.info(`Skipped commenting on ${ticketIdentifier} (likely no synced Slack thread): ${e.message}`);
+                  }
+                }
+
+                return result;
               });
 
               const updateResults = await Promise.allSettled(updatePromises);
@@ -169,7 +191,7 @@ jobs:
                 const ticketIdentifier = ticketsToUpdate[index];
                 if (result.status === 'fulfilled') {
                   const updateResult = result.value;
-                  if (updateResult.issueUpdate.success) {
+                  if (updateResult.issueUpdate?.success) {
                     core.info(`Successfully updated ticket ${ticketIdentifier} to state "${updateResult.issueUpdate.issue.state.name}".`);
                   } else {
                     core.error(`Failed to update ticket ${ticketIdentifier}, success was false.`);


### PR DESCRIPTION
## 📝 Summary
### Before
Today, when a task is released, we move the task to Released column in Linear.

### After
With this change, on top of that, we also comment in the original Slack thread inside the Linear task that the task is released.  This is because we don't want to rely on Linear Slack native integration for notifying Slack when a task is released as it's not very configurable on Linear side.

## ☑ Checklist
- [x] I have linked this PR to a Linear Card: fixes PLAT-1720.
- [ ] (_optional_) I plan to write about this PR in #product-updates / Canny / Help Center / Docs / [API Changelog](https://docs.kindly.ai/api/changelog)
- [ ] (_optional_) I have added prometheus or mixpanel events for this feature.
- [ ] (_optional_) I have added tests. 

<!-- 
📝 Summary - Briefly describe what has changed in this pull request. - If this is still a work in progress, create a draft PR. 
✨ Screenshots/GIFs - Include screenshots, videos and/or GIFs showcasing the changes, if applicable. It really helps to understand the changes.
💁‍♂️ Reviewer Instructions - Provide any special instructions for reviewers: - Highlight areas of the code that need more attention. - Note dependencies, context, or questions that will help the reviewer. 
🚀 Deployment Steps - If there are environment variables, migrations, or dependent PRs, mention them here. - Provide step-by-step deployment instructions if necessary. 
☑ Checklist - Make sure to check off all applicable items before submitting. - Link this PR to its relevant Linear Card. - Consider adding observability (e.g., Prometheus/Mixpanel) for new features. - Add/update tests as needed to ensure reliability. 
💡 Additional Notes: - Check out gitmoji-cli for easy lookups: https://github.com/carloscuesta/gitmoji-cli. - Provide a meaningful PR title starting with a gitmoji (see https://gitmoji.dev/ for examples). - Consider mentioning changes in #product-updates, Canny, the Help Center, or API changelogs, as needed. 
-->
