### PR TITLE
✨ Add Team Intel and Atlas to Linear integration

### DIFF
--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get previous release tag
         id: previous_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const releases = await github.rest.repos.listReleases({
@@ -45,17 +45,18 @@ jobs:
 
       - name: Comment on Linear tickets in synced Slack threads
         if: steps.pr_numbers.outputs.numbers && steps.pr_numbers.outputs.numbers != '[]'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumbers = ${{ steps.pr_numbers.outputs.numbers }};
             const linearApiKey = '${{ secrets.linear-api-key }}';
 
-            const TICKET_PATTERN = /(PLAT|CORE|INTEL)-\d+/g;
+            const TICKET_PATTERN = /(PLAT|CORE|INTEL|ATLAS)-\d+/g;
             const MERGED_STATE_IDS = [
               'b00c5e2d-f7b0-4134-9181-35169a0ce16b', // "🔀 Merged" state ID from Team Canvas
               '1c81a071-5649-4722-820d-6fb1aa5a05b6', // "🔀 Merged" state ID from Team Intel
               '51f1e757-1321-49fd-822b-8cb0e0703cec', // "🔀 Merged" state ID from Team Engine
+              'ca456b3c-223a-4266-b043-3386ea7d89ce', // "🔀 Merged" state ID from Team Atlas
             ];
 
             if (!prNumbers || prNumbers.length === 0) {

--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -51,10 +51,11 @@ jobs:
             const prNumbers = ${{ steps.pr_numbers.outputs.numbers }};
             const linearApiKey = '${{ secrets.linear-api-key }}';
 
-            const TICKET_PATTERN = /(PLAT|CORE)-\d+/g;
+            const TICKET_PATTERN = /(PLAT|CORE|INTEL)-\d+/g;
             const MERGED_STATE_IDS = [
-              'b00c5e2d-f7b0-4134-9181-35169a0ce16b', // "🔀 Merged" state ID from Team Platform
-              '51f1e757-1321-49fd-822b-8cb0e0703cec', // "🔀 Merged" state ID from Team Core
+              'b00c5e2d-f7b0-4134-9181-35169a0ce16b', // "🔀 Merged" state ID from Team Canvas
+              '1c81a071-5649-4722-820d-6fb1aa5a05b6', // "🔀 Merged" state ID from Team Intel
+              '51f1e757-1321-49fd-822b-8cb0e0703cec', // "🔀 Merged" state ID from Team Engine
             ];
 
             if (!prNumbers || prNumbers.length === 0) {


### PR DESCRIPTION
## 📝 Summary
Adds team Intel and Atlas data to make the Linear integration work on our tasks.


## ☑ Checklist
- [x] I have linked this PR to a Linear Card: fixes INTEL-90.
- [ ] (_optional_) I plan to write about this PR in #product-updates / Canny / Help Center / Docs / [API Changelog](https://docs.kindly.ai/api/changelog)
- [ ] (_optional_) I have added prometheus or mixpanel events for this feature.
- [ ] (_optional_) I have added tests. 

<!-- 
📝 Summary - Briefly describe what has changed in this pull request. - If this is still a work in progress, create a draft PR. 
✨ Screenshots/GIFs - Include screenshots, videos and/or GIFs showcasing the changes, if applicable. It really helps to understand the changes.
💁‍♂️ Reviewer Instructions - Provide any special instructions for reviewers: - Highlight areas of the code that need more attention. - Note dependencies, context, or questions that will help the reviewer. 
🚀 Deployment Steps - If there are environment variables, migrations, or dependent PRs, mention them here. - Provide step-by-step deployment instructions if necessary. 
☑ Checklist - Make sure to check off all applicable items before submitting. - Link this PR to its relevant Linear Card. - Consider adding observability (e.g., Prometheus/Mixpanel) for new features. - Add/update tests as needed to ensure reliability. 
💡 Additional Notes: - Check out gitmoji-cli for easy lookups: https://github.com/carloscuesta/gitmoji-cli. - Provide a meaningful PR title starting with a gitmoji (see https://gitmoji.dev/ for examples). - Consider mentioning changes in #product-updates, Canny, the Help Center, or API changelogs, as needed. 
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI workflow-only changes that expand which Linear ticket prefixes/states are recognized; main risk is missed or extra ticket comments if IDs/patterns are wrong.
> 
> **Overview**
> Updates the reusable `linear-release.yml` workflow to use `actions/github-script@v8`.
> 
> Expands the Linear ticket matching and merged-state filtering to include `INTEL` and `ATLAS` (and updates the associated merged state IDs), so release notifications can be posted to synced Slack threads for those teams’ tickets as well.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8348f45ca2e91c5aa914a4592efff23f9bcdfa00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->