### PR TITLE
✨ Add "🚀 released" label to PRs included in a release

### DIFF
--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Label released PRs
         if: steps.pr_numbers.outputs.numbers && steps.pr_numbers.outputs.numbers != '[]'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -43,6 +43,38 @@ jobs:
           pr_numbers_json=$(git log $prev_tag..$current_tag --pretty=%s | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | jq -scR 'split("\n") | map(select(length > 0)) | map(tonumber)')
           echo "numbers=${pr_numbers_json}" >> $GITHUB_OUTPUT
 
+      - name: Label released PRs
+        if: steps.pr_numbers.outputs.numbers && steps.pr_numbers.outputs.numbers != '[]'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumbers = ${{ steps.pr_numbers.outputs.numbers }};
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const labelName = 'released';
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: labelName });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({ owner, repo, name: labelName, color: '6f42c1', description: 'Included in a production release' });
+                core.info(`Created "${labelName}" label.`);
+              } else {
+                throw e;
+              }
+            }
+
+            const results = await Promise.allSettled(
+              prNumbers.map(pr =>
+                github.rest.issues.addLabels({ owner, repo, issue_number: pr, labels: [labelName] })
+              )
+            );
+
+            results.forEach((r, i) => {
+              if (r.status === 'fulfilled') core.info(`Labeled PR #${prNumbers[i]}`);
+              else core.warning(`Failed to label PR #${prNumbers[i]}: ${r.reason.message}`);
+            });
+
       - name: Comment on Linear tickets in synced Slack threads
         if: steps.pr_numbers.outputs.numbers && steps.pr_numbers.outputs.numbers != '[]'
         uses: actions/github-script@v8

--- a/.github/workflows/(reusable) linear-release.yml
+++ b/.github/workflows/(reusable) linear-release.yml
@@ -51,7 +51,7 @@ jobs:
             const prNumbers = ${{ steps.pr_numbers.outputs.numbers }};
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const labelName = 'released';
+            const labelName = '🚀 released';
 
             try {
               await github.rest.issues.getLabel({ owner, repo, name: labelName });


### PR DESCRIPTION
## 📝 Summary

When a GitHub Release is published, the reusable Linear-release workflow now also applies a `🚀 released` label to every PR included in that release. This makes it possible to tell at a glance — directly from a PR's label list — whether a change has shipped to production, without having to cross-reference the Releases page (usually 4-5 clicks away).

The label is created automatically (purple, "Included in a production release") the first time the workflow runs in a repo that doesn't have it yet.

<sub>Last commit accounted for: 5db7705</sub>

## ☑ Checklist
- [ ] I have linked this PR to a Linear Card: fixes ABC-123.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds GitHub labeling during releases; failures are non-blocking via `continue-on-error`, but could produce noisy logs or miss labels if API/permissions differ.
> 
> **Overview**
> When a GitHub Release is published, the reusable `linear-release` workflow now **automatically labels all PRs included in the release** with `🚀 released`.
> 
> The workflow ensures the label exists (creating it with a defined color/description if missing) and then applies it to each PR number detected between the previous and current release tags, logging successes/failures without failing the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7044f0ff0ba815192efedfe076b2d90619ebb75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->